### PR TITLE
Add CI file with auto release upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,27 +13,6 @@ permissions:
   contents: write
 
 jobs:
-  # --- Проверки (ветка main + PR) ---
-  lint-test:
-    name: Test
-    runs-on: ubuntu-latest
-    # Запускаем только для PR и main (не для тегов)
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-
-
-      - name: Go test
-        run: go test ./... -race
-
   # --- Сборка + релиз (только для тегов) ---
   build-and-release:
     name: Build & Release (${{ matrix.os }})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add GitHub Actions workflow to build Go binaries for Windows/macOS on tag pushes and upload them to GitHub Releases.
> 
> - **CI/CD**:
>   - **New workflow** in `.github/workflows/ci.yml`:
>     - Triggers on `pull_request` and `push`; build-and-release job runs only for tag refs `v*`.
>     - Matrix builds on `windows-latest` and `macos-latest`; sets up Go from `go.mod` with caching.
>     - Builds artifacts to `dist/` with tag in filenames using `-ldflags` and OS-specific outputs.
>     - Uploads `dist/*` to GitHub Release via `softprops/action-gh-release@v2` with `contents: write` permissions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f97642df69b575f9e8f9ae0cc01283513774448. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->