### PR TITLE
Revert PR #23: remove unintended merge into main

### DIFF
--- a/core/controller.go
+++ b/core/controller.go
@@ -659,45 +659,19 @@ func (ac *AppController) GetVPNButtonState() VPNButtonState {
 	return state
 }
 
-// addHideDockMenuItem adds "Hide app from Dock" toggle menu item (macOS only)
-func (ac *AppController) addHideDockMenuItem(menuItems []*fyne.MenuItem) []*fyne.MenuItem {
-	if runtime.GOOS != "darwin" {
-		return menuItems
-	}
-
-	hideDockEnabled := ac.UIService.HideAppFromDock
-	hideDockLabel := "Hide app from Dock"
-	if hideDockEnabled {
-		hideDockLabel = "✓ " + hideDockLabel
-	}
-
-	menuItems = append(menuItems, fyne.NewMenuItem(hideDockLabel, func() {
-		ac.UIService.HideAppFromDock = !ac.UIService.HideAppFromDock
-		if ac.UIService.UpdateTrayMenuFunc != nil {
-			ac.UIService.UpdateTrayMenuFunc()
-		}
-	}))
-	menuItems = append(menuItems, fyne.NewMenuItemSeparator())
-
-	return menuItems
-}
-
 // CreateTrayMenu creates the system tray menu with proxy selection submenu
 func (ac *AppController) CreateTrayMenu() *fyne.Menu {
 	if ac.APIService == nil {
 		// Return minimal menu if APIService is not initialized
-		menuItems := []*fyne.MenuItem{
+		return fyne.NewMenu("Singbox Launcher", []*fyne.MenuItem{
 			fyne.NewMenuItem("Open", func() {
 				if ac.UIService != nil && ac.UIService.MainWindow != nil {
 					ac.UIService.MainWindow.Show()
 				}
 			}),
 			fyne.NewMenuItemSeparator(),
-		}
-
-		menuItems = ac.addHideDockMenuItem(menuItems)
-		menuItems = append(menuItems, fyne.NewMenuItem("Quit", ac.GracefulExit))
-		return fyne.NewMenu("Singbox Launcher", menuItems...)
+			fyne.NewMenuItem("Quit", ac.GracefulExit),
+		}...)
 	}
 
 	// Get proxies from current group
@@ -805,9 +779,6 @@ func (ac *AppController) CreateTrayMenu() *fyne.Menu {
 		menuItems = append(menuItems, selectProxyItem)
 		menuItems = append(menuItems, fyne.NewMenuItemSeparator())
 	}
-
-	// Add "Hide app from Dock" toggle (macOS only) before Quit
-	menuItems = ac.addHideDockMenuItem(menuItems)
 
 	// Add Quit item
 	menuItems = append(menuItems, fyne.NewMenuItem("Quit", ac.GracefulExit))

--- a/core/services/ui_service.go
+++ b/core/services/ui_service.go
@@ -43,9 +43,6 @@ type UIService struct {
 	TrayMenuUpdateMutex      sync.Mutex
 	TrayMenuUpdateTimer      *time.Timer
 
-	// Dock icon visibility state (macOS only)
-	HideAppFromDock bool
-
 	// Callbacks for UI logic
 	RefreshAPIFunc           func()
 	ResetAPIStateFunc        func()

--- a/internal/platform/dock_handler.go
+++ b/internal/platform/dock_handler.go
@@ -80,13 +80,6 @@ static void cleanupDockReopenHandlerImpl(void) {
     dockHandlerInstalled = 0;
 }
 
-// hideDockIconImpl hides the Dock icon by setting activation policy to Accessory
-// NSApplicationActivationPolicyAccessory makes the app run without showing in Dock
-// This is used for tray-only mode when user wants to hide the app from Dock
-static void hideDockIconImpl(void) {
-    [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
-}
-
 // Export functions for Go - using inline to avoid duplicate symbols
 // CGO compiles code multiple times, so we use inline to avoid symbol duplication
 static inline void singboxLauncherSetupDockReopenHandler(void) {
@@ -95,10 +88,6 @@ static inline void singboxLauncherSetupDockReopenHandler(void) {
 
 static inline void singboxLauncherCleanupDockReopenHandler(void) {
     cleanupDockReopenHandlerImpl();
-}
-
-static inline void singboxLauncherHideDockIcon(void) {
-    hideDockIconImpl();
 }
 
 // Non-inline wrappers for Go to call (inline functions can't be called from Go)
@@ -110,10 +99,6 @@ __attribute__((weak)) void callSetupDockReopenHandler(void) {
 
 __attribute__((weak)) void callCleanupDockReopenHandler(void) {
     singboxLauncherCleanupDockReopenHandler();
-}
-
-__attribute__((weak)) void callHideDockIcon(void) {
-    singboxLauncherHideDockIcon();
 }
 */
 import "C"
@@ -160,13 +145,4 @@ func CleanupDockReopenHandler() {
 	C.callCleanupDockReopenHandler()
 	dockReopenCallback = nil
 	log.Println("CleanupDockReopenHandler: Dock reopen handler cleaned up")
-}
-
-// HideDockIcon hides the Dock icon on macOS (tray-only mode)
-func HideDockIcon() {
-	if runtime.GOOS != "darwin" {
-		return
-	}
-	C.callHideDockIcon()
-	log.Println("HideDockIcon: Dock icon hidden (NSApplicationActivationPolicyAccessory)")
 }

--- a/main.go
+++ b/main.go
@@ -188,9 +188,6 @@ func main() {
 	if controller.UIService.MainWindow != nil {
 		controller.UIService.MainWindow.SetCloseIntercept(func() {
 			controller.UIService.MainWindow.Hide()
-			if controller.UIService.HideAppFromDock {
-				platform.HideDockIcon()
-			}
 		})
 	}
 


### PR DESCRIPTION
This PR reverts merge commit ba2c4c4 which was merged into main by mistake. It restores main to its previous state before that merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes Dock-hiding functionality and streamlines tray/menu logic.
> 
> - Deletes `Hide app from Dock` toggle, related state in `UIService`, and CGO hooks in `internal/platform/dock_handler.go`
> - Simplifies `CreateTrayMenu`: minimal menu returned directly when API unavailable; removes Dock toggle insertion
> - Updates window close intercept to only hide the window (no Dock icon manipulation)
> - Retains macOS Dock click reopen handler; no behavioral changes elsewhere
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bb6faf6c11312b6d37ede4682b3dec323620644. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->