### PR TITLE
chore(lint): fix errcheck/bodyclose findings and pin golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -57,7 +57,9 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          # Pinned: `latest` silently turns new linter releases into red CI on
+          # untouched code. Bump deliberately.
+          version: v2.12.2
           args: --verbose
           skip-cache: true
         env:

--- a/core/config/subscription/node_parser_amnezia.go
+++ b/core/config/subscription/node_parser_amnezia.go
@@ -115,7 +115,7 @@ func decodeAmneziaProfile(payload string) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid zlib stream: %w", err)
 	}
-	defer zr.Close()
+	defer func() { _ = zr.Close() }()
 	data, err := io.ReadAll(io.LimitReader(zr, maxAmneziaProfileJSON+1))
 	if err != nil {
 		return nil, fmt.Errorf("zlib decompression failed: %w", err)

--- a/core/core_downloader_extract_test.go
+++ b/core/core_downloader_extract_test.go
@@ -23,7 +23,7 @@ func writeTestZip(t *testing.T, dir string, entries map[string]string) string {
 	if err != nil {
 		t.Fatalf("create zip: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	zw := zip.NewWriter(f)
 	for name, content := range entries {
 		w, err := zw.Create(name)
@@ -47,7 +47,7 @@ func writeTestTarGz(t *testing.T, dir string, entries map[string]string) string 
 	if err != nil {
 		t.Fatalf("create tar.gz: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	gzw := gzip.NewWriter(f)
 	tw := tar.NewWriter(gzw)
 	for name, content := range entries {

--- a/core/debugapi/manifest_test.go
+++ b/core/debugapi/manifest_test.go
@@ -57,22 +57,22 @@ func TestManifestAndHelp(t *testing.T) {
 	defer s.Stop()
 	base := "http://127.0.0.1:" + itoa(port)
 
-	get := func(path string) (*http.Response, []byte) {
+	get := func(path string) (int, []byte) {
 		req, _ := http.NewRequest("GET", base+path, nil)
 		req.Header.Set("Authorization", "Bearer tok")
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			t.Fatalf("GET %s: %v", path, err)
 		}
+		defer func() { _ = resp.Body.Close() }()
 		body, _ := io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
-		return resp, body
+		return resp.StatusCode, body
 	}
 
 	// GET / manifest
-	resp, body := get("/")
-	if resp.StatusCode != 200 {
-		t.Fatalf("GET /: status %d", resp.StatusCode)
+	status, body := get("/")
+	if status != 200 {
+		t.Fatalf("GET /: status %d", status)
 	}
 	var manifest struct {
 		API       string         `json:"api"`
@@ -100,9 +100,9 @@ func TestManifestAndHelp(t *testing.T) {
 	}
 
 	// GET /help → endpoint list, must match the registry.
-	resp, body = get("/help")
-	if resp.StatusCode != 200 {
-		t.Fatalf("GET /help: status %d", resp.StatusCode)
+	status, body = get("/help")
+	if status != 200 {
+		t.Fatalf("GET /help: status %d", status)
 	}
 	var help struct {
 		Endpoints []endpointView `json:"endpoints"`

--- a/ui/configurator/tabs/source_tab.go
+++ b/ui/configurator/tabs/source_tab.go
@@ -120,7 +120,7 @@ func CreateSourcesTab(presenter *wizardpresentation.WizardPresenter) fyne.Canvas
 			if rc == nil {
 				return // cancelled
 			}
-			defer rc.Close()
+			defer func() { _ = rc.Close() }()
 			text, rerr := wizardbusiness.ReadSourceFileText(rc)
 			if rerr != nil {
 				dialog.ShowError(rerr, guiState.Window)
@@ -156,7 +156,7 @@ func CreateSourcesTab(presenter *wizardpresentation.WizardPresenter) fyne.Canvas
 			dialog.ShowError(oerr, guiState.Window)
 			return
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 		text, rerr := wizardbusiness.ReadSourceFileText(f)
 		if rerr != nil {
 			dialog.ShowError(rerr, guiState.Window)


### PR DESCRIPTION
## Проблема

`golangci-lint` красный на `develop` примерно с апреля и блокирует все открытые PR (включая #93 и #94). Причина — `version: latest` в workflow: линтер сам подтянулся до 2.12.2 и стал строже. Код при этом никто не менял.

## Что сделано

Семь находок — «ошибка `Close()` не проверена» там, где она ничего не значит (чтение zlib-потока, read-only файлы из диалога, тест-хелперы). Везде явное `defer func() { _ = x.Close() }()`:

- `core/config/subscription/node_parser_amnezia.go` — `zr.Close`
- `ui/configurator/tabs/source_tab.go` — `rc.Close`, `f.Close`
- `core/core_downloader_extract_test.go` — `f.Close` ×2

`core/debugapi/manifest_test.go` — отдельный случай: body **уже закрывался**, но внутри замыкания `get()`, которое возвращало `*http.Response` наружу, а bodyclose это не отслеживает. Тесту от ответа нужен был только `StatusCode`, поэтому сигнатура сменена на `(int, []byte)` — `*http.Response` больше не покидает замыкание. Реальной утечки не было, только ложное срабатывание; `nolint` не понадобился.

Плюс `version: v2.12.2` вместо `latest`, чтобы следующий релиз линтера снова не покрасил CI на нетронутом коде.

## Проверка

Локально прогнано тем же golangci-lint 2.12.2, что и в CI:

- darwin: `0 issues`
- `go build ./...` — OK
- `TestManifestAndHelp`, `TestManifestAuthAndUnknownPath` — PASS

Windows-специфичный код за build-тегами локально не проверить (кросс-компиляция без CGO ломается на Fyne/GLFW и dbus) — это подтвердит CI.

## Дальше

После мержа #93/#94 нужно пересинхронизировать (`@dependabot rebase`), чтобы они подхватили зелёный lint.
